### PR TITLE
Add serial port CAN frame test page

### DIFF
--- a/src/js/serial-test.js
+++ b/src/js/serial-test.js
@@ -1,0 +1,33 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import '../index.scss';
+import { openSerialOutput, writeLine } from './serial-out.js';
+
+let connected = false;
+const connectBtn = document.getElementById('connect');
+const sendForm = document.getElementById('send-form');
+const idInput = document.getElementById('can-id');
+const dataInputs = document.querySelectorAll('.data-byte');
+
+connectBtn.addEventListener('click', async () => {
+        try {
+                await openSerialOutput();
+                connected = true;
+                connectBtn.disabled = true;
+        } catch (err) {
+                console.error('Failed to open serial port', err);
+        }
+});
+
+sendForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        if (!connected) return;
+
+        const id = idInput.value.trim().replace(/[^0-9a-fA-F]/g, '').toUpperCase();
+        const bytes = Array.from(dataInputs, input =>
+                input.value.trim().replace(/[^0-9a-fA-F]/g, '').padStart(2, '0').toUpperCase());
+        const dataHex = id + bytes.join('');
+
+        writeLine({ dataHex });
+});

--- a/src/serial-test.html
+++ b/src/serial-test.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Serial Test</title>
+  </head>
+  <body class="p-3">
+    <div class="container">
+      <h1 class="mb-4">Serial Port Test</h1>
+      <div class="mb-3">
+        <button id="connect" class="btn btn-primary">Connect</button>
+      </div>
+      <form id="send-form" class="row g-2 align-items-end">
+        <div class="col-auto">
+          <label for="can-id" class="form-label">ID</label>
+          <input type="text" id="can-id" class="form-control text-uppercase" maxlength="8" pattern="[0-9a-fA-F]+" placeholder="1AB"/>
+        </div>
+        <div class="col-auto">
+          <label class="form-label d-block">Data Bytes</label>
+          <div id="data-bytes" class="d-flex gap-1">
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+            <input type="text" class="form-control form-control-sm text-uppercase data-byte" maxlength="2" pattern="[0-9a-fA-F]{2}" value="00"/>
+          </div>
+        </div>
+        <div class="col-auto">
+          <button type="submit" id="send" class="btn btn-success">Send</button>
+        </div>
+      </form>
+    </div>
+    <script type="module" src="js/serial-test.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `serial-test.html` with hex ID and 8 data byte inputs
- create `serial-test.js` to open Web Serial port and send concatenated hex frame

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68909c36a6cc8320994121966735fc17